### PR TITLE
Fix landing page timeout

### DIFF
--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -43,6 +43,25 @@ export function AuthProvider({ children }) {
     localStorage.setItem("sessionExpiration", expirationTime.toString());
   };
 
+  // Add this function to determine if the current path is a public route
+  const isPublicRoute = () => {
+    const publicRoutes = [
+      "/login",
+      "/register",
+      "/forgot-password",
+      "/reset-password",
+      "/verify-email",
+      "/",
+      "/welcome",
+    ];
+    const currentPath = window.location.pathname;
+
+    // Check if the current path is in the list of public routes
+    return publicRoutes.some(
+      (route) => currentPath === route || currentPath === route + "/"
+    );
+  };
+
   // Function to check if the user's email is verified and set up their session
   const checkEmailVerification = async () => {
     try {
@@ -398,6 +417,11 @@ export function AuthProvider({ children }) {
 
       // Handler function to refresh the session timeout with debounce
       const activityHandler = () => {
+        // Don't refresh session on public routes
+        if (isPublicRoute()) {
+          return;
+        }
+
         // Clear any existing timer
         if (debounceTimer) {
           clearTimeout(debounceTimer);

--- a/src/ui/components/common/SessionTimeoutModal.js
+++ b/src/ui/components/common/SessionTimeoutModal.js
@@ -14,9 +14,33 @@ function SessionTimeoutModal() {
   const [remainingTime, setRemainingTime] = useState(0);
   const [countdownInterval, setCountdownInterval] = useState(null);
 
+  // Add function to determine if the current path is a public route
+  const isPublicRoute = () => {
+    const publicRoutes = [
+      "/login",
+      "/register",
+      "/forgot-password",
+      "/reset-password",
+      "/verify-email",
+      "/",
+      "/landing",
+    ];
+    const currentPath = window.location.pathname;
+
+    // Check if the current path is in the list of public routes
+    return publicRoutes.some(
+      (route) => currentPath === route || currentPath === route + "/"
+    );
+  };
+
   useEffect(() => {
     // Function to check if we should show the warning
     const checkSessionExpiration = () => {
+      // Don't check session expiration on public routes
+      if (isPublicRoute()) {
+        return;
+      }
+
       // Get the session expiration time from localStorage
       const expirationTime = localStorage.getItem("sessionExpiration");
 

--- a/src/ui/components/common/SessionTimeoutModal.js
+++ b/src/ui/components/common/SessionTimeoutModal.js
@@ -23,7 +23,7 @@ function SessionTimeoutModal() {
       "/reset-password",
       "/verify-email",
       "/",
-      "/landing",
+      "/welcome",
     ];
     const currentPath = window.location.pathname;
 


### PR DESCRIPTION
This PR addresses a bug where users were being automatically redirected to the login page after a period of inactivity, even when on public routes like the landing page. The fix ensures that session timeouts only apply to authenticated/protected routes.